### PR TITLE
[PR-25588] Support pitchfork lint

### DIFF
--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -35,7 +35,7 @@ module Passkit
           z.print File.read(file)
         end
       end
-      zip_path
+      zip_path.to_s
     end
 
   private
@@ -157,7 +157,7 @@ module Passkit
           z.print File.read(file)
         end
       end
-      zip_path
+      zip_path.to_s
     end
   end
 end


### PR DESCRIPTION
[Talkable BE](https://github.com/talkable/talkable/pull/10999)

The issue is at the Rack middleware layer, specifically with Rack::Lint validation. Pitchfork uses Rack::Lint to validate that response bodies conform to the Rack specification.
```
app error: body.to_path must be nil or a path to an existing file (Rack::Lint::LintError)
```
The problem:
* Rack::Lint expects body.to_path to return either nil or a valid file path string
* Pathname objects have a to_path method, but it returns another Pathname object, not a string
* This violates Rack::Lint's expectations, causing the error