### PR TITLE
[PR-25613] Allow frame by excepting X-Frame-Options from response headers

### DIFF
--- a/app/controllers/passkit/api/v1/application_controller.rb
+++ b/app/controllers/passkit/api/v1/application_controller.rb
@@ -3,7 +3,7 @@
 module Passkit
   module Api
     module V1
-      class ApplicationController < ApplicationController
+      class ApplicationController < ActionController::API
         after_action :allow_iframe
 
         # The X-Frame-Options - header that indicate whether or not a browser should be allowed to render a page in a <frame>

--- a/app/controllers/passkit/api/v1/application_controller.rb
+++ b/app/controllers/passkit/api/v1/application_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Passkit
+  module Api
+    module V1
+      class ApplicationController < ApplicationController
+        after_action :allow_iframe
+
+        # The X-Frame-Options - header that indicate whether or not a browser should be allowed to render a page in a <frame>
+        def allow_iframe
+          response.headers.except! 'X-Frame-Options'
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/passkit/api/v1/application_controller.rb
+++ b/app/controllers/passkit/api/v1/application_controller.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
-
 module Passkit
   module Api
     module V1
       class ApplicationController < ActionController::API
         after_action :allow_iframe
+
+        private
 
         # The X-Frame-Options - header that indicate whether or not a browser should be allowed to render a page in a <frame>
         def allow_iframe

--- a/app/controllers/passkit/api/v1/logs_controller.rb
+++ b/app/controllers/passkit/api/v1/logs_controller.rb
@@ -1,7 +1,7 @@
 module Passkit
   module Api
     module V1
-      class LogsController < ActionController::API
+      class LogsController < ApplicationController
         def create
           params[:logs].each do |message|
             Log.create!(content: message)

--- a/app/controllers/passkit/api/v1/passes_controller.rb
+++ b/app/controllers/passkit/api/v1/passes_controller.rb
@@ -1,7 +1,7 @@
 module Passkit
   module Api
     module V1
-      class PassesController < ActionController::API
+      class PassesController < ApplicationController
         before_action :decrypt_payload, only: :create
 
         def create

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -5,7 +5,7 @@ module Passkit
       # This Class Implements the Apple PassKit API
       # @see Apple: https://developer.apple.com/library/archive/documentation/PassKit/Reference/PassKit_WebService/WebService.html
       # @see Android: https://walletpasses.io/developer/
-      class RegistrationsController < ActionController::API
+      class RegistrationsController < ApplicationController
         before_action :load_pass, only: %i[create destroy]
         before_action :load_device, only: %i[show destroy]
 


### PR DESCRIPTION
- Provided `ApplicationController` class
- Added new method `allow_iframe` to replace it with default value for iOS 26 - `SAMEORIGIN`, maybe for other browsers on iOS 26 and other Apple platforms.